### PR TITLE
Customize the systemd export template

### DIFF
--- a/data/export/systemd/process.service.erb
+++ b/data/export/systemd/process.service.erb
@@ -3,14 +3,13 @@ PartOf=<%= app %>.target
 StopWhenUnneeded=yes
 
 [Service]
-User=<%= user %>
 WorkingDirectory=<%= engine.root %>
 Environment=PORT=<%= port %>
 Environment=PS=<%= process_name %>
 <% engine.env.each_pair do |var,env| -%>
 Environment="<%= var %>=<%= env %>"
 <% end -%>
-ExecStart=/bin/bash -lc 'exec -a "<%= app %>-<%= process_name %>" <%= process.command %>'
+ExecStart=/bin/bash -lc 'exec -a /home/"<%= user %>"/.rbenv/shims/"<%= app %>-<%= process_name %>" <%= process.command %>'
 Restart=always
 RestartSec=14s
 StandardInput=null


### PR DESCRIPTION
[x] Customize the systemd export template to use path to rbenv shim in service start command
[] Add an rbenv flag to make the shim path optional in the template
[] Ressurect and refactor the `--template` functionality
[] Add a `--sidekiq` flag that automatically includes systemd optimizations for sidekiq

Some of the ideas in this pr come from this article:
https://dev.to/kevinluo201/start-sidekiq-6-as-daemon-in-production-environment-on-ubuntu-20-04-4m7b

Alternatives to investigate:
Can we use this instead? https://github.com/seuros/capistrano-sidekiq